### PR TITLE
typofix and add verbose infos

### DIFF
--- a/pyHashcat-0.2/pyHashcat/HashcatWrapper.py
+++ b/pyHashcat-0.2/pyHashcat/HashcatWrapper.py
@@ -307,9 +307,13 @@ class oclHashcatWrapper(object):
             
             if gcard_type.lower() == "cuda":
                 self.cmd = "./cudaHashcat"+bits + ".bin"
+                if self.verbose: print "[*] Using CUDA version"
             
             else:
                 self.cmd = "./oclHashcat"+bits  + ".bin"
+                if self.verbose: print "[*] Using OCL version"
+
+            if self.verbose: print "[*] Using cmd: " + self.cmd
                             
     def __enter__(self):
         return self


### PR DESCRIPTION
1: The HMAC variants where missing " = $pass)" and " = $salt)".

2: Also print the debug informations when running on Linux.
